### PR TITLE
Dynamic penumbra shadows in PCF

### DIFF
--- a/builtin/settingtypes.txt
+++ b/builtin/settingtypes.txt
@@ -626,8 +626,8 @@ shadow_update_time (Map update time) float 0.2 0.001 0.2
 
 #    Set the soft shadow radius size.
 #    Lower values mean sharper shadows bigger values softer.
-#    Minimun value 1.0 and max value 5.0 
-shadow_soft_radius (Soft shadow radius) float 1.0 1.0 5.0
+#    Minimun value 1.0 and max value 10.0
+shadow_soft_radius (Soft shadow radius) float 1.0 1.0 10.0
 
 #    Set the tilt of Sun/Moon orbit in degrees
 #    Value of 0 means no tilt / vertical orbit.

--- a/client/shaders/nodes_shader/opengl_fragment.glsl
+++ b/client/shaders/nodes_shader/opengl_fragment.glsl
@@ -193,6 +193,7 @@ float getPenumbraRadius(sampler2D shadowsampler, vec2 smTexCoord, float realDist
 	float baseLength = getBaseLength(smTexCoord);
 	float perspectiveFactor;
 	float bound = clamp(PCFBOUND * (1 - baseLength), 0.5, PCFBOUND);
+	int n = 0;
 
 	for (y = -bound; y <= bound; y += 1.0)
 	for (x = -bound; x <= bound; x += 1.0) {
@@ -201,11 +202,16 @@ float getPenumbraRadius(sampler2D shadowsampler, vec2 smTexCoord, float realDist
 		clampedpos = clampedpos * texture_size * perspectiveFactor * maxRadius * perspectiveFactor + smTexCoord.xy;
 
 		pointDepth = getHardShadowDepth(shadowsampler, clampedpos.xy, realDistance);
-		depth = max(depth, pointDepth);
+		if (pointDepth > -0.01) {
+			depth += pointDepth;
+			n += 1;
+		}
 	}
 
+	depth = depth / n;
+
 	depth = pow(clamp(depth, 0.0, 1000.0), 1.6) / 0.001;
-	return depth * maxRadius;
+	return max(0.5, depth * maxRadius);
 }
 
 #ifdef POISSON_FILTER

--- a/client/shaders/nodes_shader/opengl_fragment.glsl
+++ b/client/shaders/nodes_shader/opengl_fragment.glsl
@@ -292,7 +292,7 @@ vec4 getShadowColor(sampler2D shadowsampler, vec2 smTexCoord, float realDistance
 	float perspectiveFactor;
 
 	float texture_size = 1.0 / (f_textureresolution * 0.5);
-	int samples = int(clamp(PCFSAMPLES * (1 - baseLength), 1, PCFSAMPLES));
+	int samples = int(clamp(PCFSAMPLES * (1 - baseLength) * (1 - baseLength), 1, PCFSAMPLES));
 	int init_offset = int(floor(mod(((smTexCoord.x * 34.0) + 1.0) * smTexCoord.y, 64.0-samples)));
 	int end_offset = int(samples) + init_offset;
 
@@ -322,7 +322,7 @@ float getShadow(sampler2D shadowsampler, vec2 smTexCoord, float realDistance)
 	float perspectiveFactor;
 
 	float texture_size = 1.0 / (f_textureresolution * 0.5);
-	int samples = int(clamp(PCFSAMPLES * (1 - baseLength), 1, PCFSAMPLES));
+	int samples = int(clamp(PCFSAMPLES * (1 - baseLength) * (1 - baseLength), 1, PCFSAMPLES));
 	int init_offset = int(floor(mod(((smTexCoord.x * 34.0) + 1.0) * smTexCoord.y, 64.0-samples)));
 	int end_offset = int(samples) + init_offset;
 

--- a/client/shaders/nodes_shader/opengl_fragment.glsl
+++ b/client/shaders/nodes_shader/opengl_fragment.glsl
@@ -188,7 +188,7 @@ float getPenumbraRadius(sampler2D shadowsampler, vec2 smTexCoord, float realDist
 	float y, x;
 	float depth = 0.0;
 	float pointDepth;
-	float maxRadius = SOFTSHADOWRADIUS * multiplier;
+	float maxRadius = SOFTSHADOWRADIUS * 5.0 * multiplier;
 
 	float baseLength = getBaseLength(smTexCoord);
 	float perspectiveFactor;


### PR DESCRIPTION
This PR adds dynamic size of penumbra shadow based on length of the shadow ray _and_ corrects SM texture offsets.

## To do

- [x] Refactor correction into a common function to be used by all 4 filter variants (color/no-color, PCF/Poisson disk)
- [x] Correct Poisson and color shadows implementations.

## How to test

Just play :)